### PR TITLE
Fix: totalList api

### DIFF
--- a/src/main/java/zerobase/sijak/controller/HeartController.java
+++ b/src/main/java/zerobase/sijak/controller/HeartController.java
@@ -1,0 +1,34 @@
+package zerobase.sijak.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zerobase.sijak.service.HeartService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class HeartController {
+
+    private final HeartService heartService;
+
+    @GetMapping("/api/hearts")
+    public ResponseEntity<?> readHearts(@RequestHeader("Authorization") String token) {
+
+        heartService.readHearts(token);
+
+        return null;
+    }
+
+
+    @PostMapping("hearts")
+    public ResponseEntity<?> appendHearts(@RequestHeader("Authorization") String token) {
+
+        heartService.appendHearts(token);
+
+        return null;
+    }
+
+}

--- a/src/main/java/zerobase/sijak/controller/LectureController.java
+++ b/src/main/java/zerobase/sijak/controller/LectureController.java
@@ -7,11 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import zerobase.sijak.dto.HttpResponse;
+import zerobase.sijak.dto.LectureHomeResponse;
 import zerobase.sijak.persist.domain.Lecture;
 import zerobase.sijak.service.LectureService;
 
@@ -21,45 +19,47 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class LectureController {
 
     private final LectureService lectureService;
 
-//    @GetMapping("/api/lectures")
-//    public ResponseEntity<HttpResponse> readLectures() {
-//        return ResponseEntity.ok(HttpResponse.res(HttpStatus.OK, HttpStatus.OK.toString(), lectureService.readLectures()));
-//    }
-
-    @GetMapping("/api/lectures")
-    public ResponseEntity<HttpResponse> readLectures(@RequestParam(defaultValue = "0") int page,
+    @GetMapping("/lectures")
+    public ResponseEntity<HttpResponse> readLectures(@RequestHeader("Authorization") String token,
+                                                     @RequestParam(defaultValue = "0") int page,
                                                      @RequestParam(defaultValue = "10") int size) {
 
         Pageable pageable = PageRequest.of(page, size);
-        Slice<Lecture> lectures = lectureService.readLectures(pageable);
+        Slice<LectureHomeResponse> lectures = lectureService.readLectures(token, pageable);
 
-        return ResponseEntity.ok(HttpResponse.res(HttpStatus.OK, HttpStatus.OK.toString(), Map.of("data", lectures.getContent(), "hasNext", lectures.hasNext())));
-
-
+        return ResponseEntity.ok(HttpResponse.res(HttpStatus.OK, HttpStatus.OK.toString(),
+                Map.of("data", lectures.getContent(), "hasNext", lectures.hasNext())));
     }
 
-    @GetMapping("/api/lectures/{id}")
+    @GetMapping("/lectures/{id}")
     public ResponseEntity<HttpResponse> readLecture(@PathVariable int id) {
         return ResponseEntity.ok(HttpResponse.res(HttpStatus.OK, HttpStatus.OK.toString(), lectureService.readLecture(id)));
     }
 
-    @GetMapping("/api/home")
+    @GetMapping("/home")
     public ResponseEntity<HttpResponse> readLecturs() {
         return null;
     }
 
-    @GetMapping("/api/mypage")
+    @GetMapping("/mypage")
     public ResponseEntity<HttpResponse> readMypage() {
         return null;
     }
 
-    @GetMapping("/api/wishes")
+    @GetMapping("/wishes")
     public ResponseEntity<HttpResponse> readWishes() {
         return null;
+    }
+
+    @PostMapping("/wishes/{lecture_id}")
+    public ResponseEntity<HttpResponse> createWish(@RequestHeader("Authorization") String token, @PathVariable int lecture_id) {
+        lectureService.toggleHeart(token, lecture_id);
+        return ResponseEntity.ok(HttpResponse.res(HttpStatus.OK, HttpStatus.OK.toString(), "success"));
     }
 
 

--- a/src/main/java/zerobase/sijak/dto/LectureDetailResponse.java
+++ b/src/main/java/zerobase/sijak/dto/LectureDetailResponse.java
@@ -1,0 +1,4 @@
+package zerobase.sijak.dto;
+
+public class LectureDetailResponse {
+}

--- a/src/main/java/zerobase/sijak/dto/LectureHomeResponse.java
+++ b/src/main/java/zerobase/sijak/dto/LectureHomeResponse.java
@@ -1,0 +1,24 @@
+package zerobase.sijak.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LectureHomeResponse {
+
+    Integer id;
+
+    String name;
+
+    String time;
+
+    String address;
+
+    boolean isHeart;
+
+}

--- a/src/main/java/zerobase/sijak/persist/domain/Heart.java
+++ b/src/main/java/zerobase/sijak/persist/domain/Heart.java
@@ -24,7 +24,7 @@ public class Heart {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "class_id")
+    @JoinColumn(name = "lecture_id")
     private Lecture lecture;
 
 }

--- a/src/main/java/zerobase/sijak/persist/domain/Lecture.java
+++ b/src/main/java/zerobase/sijak/persist/domain/Lecture.java
@@ -59,8 +59,7 @@ public class Lecture {
 
     private String status;
 
-    @Builder.Default
-    private Integer view = 0;
+    private Integer view;
 
     @Builder.Default
     private String category = "미정";
@@ -83,22 +82,4 @@ public class Lecture {
     @Builder.Default
     private List<Review> reviews = new ArrayList<>();
 
-    public Lecture(LectureCreateRequest lectureCreateRequest) {
-        this.name = lectureCreateRequest.getName();
-        this.description = lectureCreateRequest.getDescription();
-        this.price = lectureCreateRequest.getPrice();
-        this.capacity = lectureCreateRequest.getCapacity();
-        this.dayOfWeek = lectureCreateRequest.getDayOfWeek();
-        this.time = lectureCreateRequest.getTime();
-        this.link = lectureCreateRequest.getLink();
-        this.location = lectureCreateRequest.getLocation();
-        this.status = lectureCreateRequest.getStatus();
-        this.hearts = lectureCreateRequest.getHearts();
-        this.reviews = lectureCreateRequest.getReviews();
-        this.imageUrls = lectureCreateRequest.getImageUrls();
-        this.centerName = lectureCreateRequest.getCenterName();
-        this.address = lectureCreateRequest.getAddress();
-        this.latitude = lectureCreateRequest.getLatitude();
-        this.longitude = lectureCreateRequest.getLongitude();
-    }
 }

--- a/src/main/java/zerobase/sijak/persist/repository/HeartRepository.java
+++ b/src/main/java/zerobase/sijak/persist/repository/HeartRepository.java
@@ -1,0 +1,17 @@
+package zerobase.sijak.persist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.sijak.persist.domain.Heart;
+import zerobase.sijak.persist.domain.Lecture;
+
+import java.util.List;
+
+@Repository
+public interface HeartRepository extends JpaRepository<Heart, Integer> {
+
+    boolean existsByLectureIdAndMemberId(Integer lectureId, Integer memberId);
+
+    List<Heart> findAllByMemberId(Integer memberId);
+
+}

--- a/src/main/java/zerobase/sijak/service/HeartService.java
+++ b/src/main/java/zerobase/sijak/service/HeartService.java
@@ -1,0 +1,52 @@
+package zerobase.sijak.service;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import zerobase.sijak.exception.EmailNotExistException;
+import zerobase.sijak.exception.ErrorCode;
+import zerobase.sijak.jwt.JwtTokenProvider;
+import zerobase.sijak.persist.domain.Heart;
+import zerobase.sijak.persist.domain.Lecture;
+import zerobase.sijak.persist.domain.Member;
+import zerobase.sijak.persist.repository.HeartRepository;
+import zerobase.sijak.persist.repository.MemberRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HeartService {
+
+    private final HeartRepository heartRepository;
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    public boolean isHearted(int lectureId, int memberId) {
+        return heartRepository.existsByLectureIdAndMemberId(lectureId, memberId);
+    }
+
+    public List<Lecture> readHearts(String token) {
+        String jwtToken = token.substring(7);
+        Claims claims = jwtTokenProvider.parseClaims(jwtToken);
+        log.info("email : {}", claims.getSubject());
+
+        Member member = memberRepository.findByAccountEmail(claims.getSubject());
+        if (member == null) throw new EmailNotExistException("해당 유저 email이 존재하지 않습니다.", ErrorCode.EMAIL_NOT_EXIST);
+
+        List<Heart> hearts = heartRepository.findAllByMemberId(member.getId());
+        return hearts.stream()
+                .map(Heart::getLecture)
+                .collect(Collectors.toList());
+
+    }
+
+    public void appendHearts(String token) {
+
+    }
+
+}

--- a/src/main/java/zerobase/sijak/service/LectureService.java
+++ b/src/main/java/zerobase/sijak/service/LectureService.java
@@ -1,30 +1,76 @@
 package zerobase.sijak.service;
 
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestHeader;
+import zerobase.sijak.dto.LectureHomeResponse;
+import zerobase.sijak.exception.EmailNotExistException;
 import zerobase.sijak.exception.ErrorCode;
 import zerobase.sijak.exception.IdNotExistException;
+import zerobase.sijak.jwt.JwtTokenProvider;
+import zerobase.sijak.persist.domain.Heart;
 import zerobase.sijak.persist.domain.Lecture;
+import zerobase.sijak.persist.domain.Member;
 import zerobase.sijak.persist.repository.LectureRepository;
+import zerobase.sijak.persist.repository.MemberRepository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class LectureService {
 
+    private final HeartService heartService;
+    private final KakaoService kakaoService;
     private final LectureRepository lectureRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
-    public List<Lecture> readLectures() {
-        return lectureRepository.findAll();
-    }
 
-    public Slice<Lecture> readLectures(Pageable pageable) {
-        return lectureRepository.findAll(pageable);
+    public Slice<LectureHomeResponse> readLectures(String token, Pageable pageable) {
+
+        if (token == null || token.isEmpty()) {
+            Slice<Lecture> lectures = lectureRepository.findAll(pageable);
+            List<LectureHomeResponse> lectureHomeResponseList = lectures.getContent().stream().map(lecture -> {
+                return LectureHomeResponse.builder()
+                        .id(lecture.getId())
+                        .name(lecture.getName())
+                        .time(lecture.getTime())
+                        .address(lecture.getAddress())
+                        .isHeart(false).build();
+            }).toList();
+            return new SliceImpl<>(lectureHomeResponseList, pageable, lectures.hasNext());
+        } else {
+            String jwtToken = token.substring(7);
+            Claims claims = jwtTokenProvider.parseClaims(jwtToken);
+            log.info("readLectures: token not null");
+
+            Member member = memberRepository.findByAccountEmail(claims.getSubject());
+            if (member == null) {
+                throw new EmailNotExistException("해당 유저 email이 존재하지 않습니다.", ErrorCode.EMAIL_NOT_EXIST);
+            }
+
+            Slice<Lecture> lectures = lectureRepository.findAll(pageable);
+            List<LectureHomeResponse> lectureHomeResponseList = lectures.getContent().stream().map(lecture -> {
+                boolean isHeart = heartService.isHearted(lecture.getId(), member.getId());
+                return LectureHomeResponse.builder()
+                        .id(lecture.getId())
+                        .name(lecture.getName())
+                        .time(lecture.getTime())
+                        .address(lecture.getAddress())
+                        .isHeart(isHeart).build();
+            }).toList();
+            return new SliceImpl<>(lectureHomeResponseList, pageable, lectures.hasNext());
+        }
     }
 
     public Lecture readLecture(Integer id) {
@@ -37,6 +83,30 @@ public class LectureService {
         lectureRepository.save(lecture);
 
         return lecture;
+    }
+
+    // 사용자 정보를 받아온다.
+    // 사용자 정보에 대해서 member_id를 가져오고
+    public void readHearts() {
+
+    }
+
+    public void toggleHeart(String token, int lecture_id) {
+
+        String jwtToken = token.substring(7);
+        Claims claims = jwtTokenProvider.parseClaims(jwtToken);
+        log.info("email : {}", claims.getSubject());
+
+        Member member = memberRepository.findByAccountEmail(claims.getSubject());
+        if (member == null) throw new EmailNotExistException("해당 유저 email이 존재하지 않습니다.", ErrorCode.EMAIL_NOT_EXIST);
+
+        Lecture lecture = lectureRepository.findById(lecture_id)
+                .orElseThrow(() -> new IdNotExistException("해당 강좌 id가 존재하지 않습니다.", ErrorCode.LECTURE_ID_NOT_EXIST));
+
+        Heart heart = Heart.builder()
+                .member(member)
+                .lecture(lecture).build();
+
     }
 
 

--- a/src/main/java/zerobase/sijak/service/scrap/GangseoScrapService.java
+++ b/src/main/java/zerobase/sijak/service/scrap/GangseoScrapService.java
@@ -39,7 +39,7 @@ public class GangseoScrapService {
     private final TeacherRepository teacherRepository;
     private final CareerRepository careerRepository;
 
-    // @Scheduled(fixedRate = 10000000)
+    //@Scheduled(fixedRate = 10000000)
     public void scrapNowon() throws InterruptedException {
 
         String name = "", time = "", price = "", href = "";
@@ -58,7 +58,7 @@ public class GangseoScrapService {
         driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(120));
 
         String GANGSEO_URL = "https://50plus.or.kr/gsc/education.do?page=%d&";
-        int idx = 2;
+        int idx = 1;
         while (true) {
             String url = String.format(GANGSEO_URL, idx);
             System.out.println("url :" + url);
@@ -119,6 +119,7 @@ public class GangseoScrapService {
                                     .price(price)
                                     .capacity(capacity)
                                     .link(href)
+                                    .view(0)
                                     .status("P")
                                     .latitude(37.5663709)
                                     .longitude(126.8424769)

--- a/src/main/java/zerobase/sijak/service/scrap/MapoScrapService.java
+++ b/src/main/java/zerobase/sijak/service/scrap/MapoScrapService.java
@@ -115,6 +115,7 @@ public class MapoScrapService {
                                     .price(price)
                                     .capacity(capacity)
                                     .status("P")
+                                    .view(0)
                                     .latitude(37.556445)
                                     .longitude(126.946607)
                                     .centerName("마포시니어클럽")

--- a/src/main/java/zerobase/sijak/service/scrap/NowonScrapService.java
+++ b/src/main/java/zerobase/sijak/service/scrap/NowonScrapService.java
@@ -119,6 +119,7 @@ public class NowonScrapService {
                                     .price(price)
                                     .capacity(capacity)
                                     .link(href)
+                                    .view(0)
                                     .status("P")
                                     .latitude(37.6561352)
                                     .longitude(127.0707057)

--- a/src/main/java/zerobase/sijak/service/scrap/SongpaScrapService.java
+++ b/src/main/java/zerobase/sijak/service/scrap/SongpaScrapService.java
@@ -37,7 +37,7 @@ public class SongpaScrapService {
     private final TeacherRepository teacherRepository;
     private final CareerRepository careerRepository;
 
-    @Scheduled(fixedRate = 10000000)
+    //@Scheduled(fixedRate = 10000000)
     public void scrapMapo() throws InterruptedException {
 
         String name = "", time = "", price = "", href = "", dayOfWeek = "", location = "";
@@ -116,13 +116,14 @@ public class SongpaScrapService {
                             log.info("location : {}", location);
                             log.info("capacity : {}", capacity);
 
-                            LectureCreateRequest lectureCreateRequest = LectureCreateRequest.builder()
+                            Lecture lecture = Lecture.builder()
                                     .name(name)
                                     .link(href)
                                     .time(time)
                                     .dayOfWeek(dayOfWeek)
                                     .location(location)
                                     .price(price)
+                                    .view(0)
                                     .latitude(37.556445)
                                     .longitude(126.946607)
                                     .address("서울특별시 마포구 동교로8길 58")
@@ -131,7 +132,6 @@ public class SongpaScrapService {
                                     .status("P")
                                     .build();
 
-                            Lecture lecture = new Lecture(lectureCreateRequest);
                             Lecture lectureId = lectureRepository.save(lecture);
                             lId = lectureId.getId();
                             log.info("lId : {} ", lId);


### PR DESCRIPTION
유저가 "맞냐, 아니냐"에 따라서 좋아요 버전을 표출해줄 수 있는가에 대해 의문이 들었습니다.
많은 생각과 서치 끝에 내가 생각했던 방식이 틀림을 알 수 있었습니다.

유저가 맞다면 유저가 좋아요 했던 정보와 클래스 정보들을 보여줘야 하고, 
유저가 아니라면 좋아요 정보가 보여지지 않게 클래스 정보들을 보여줘야했습니다.

이를 LectureResponse 라는 dto를 만들고, heart 라는 필드 변수를 만들어 내가 좋아하는 클래스의 좋아요 여부를 판단할 수 있도록 구현하였습니다. 