### PR TITLE
Feat: 랜덤 닉네임에 랜덤 숫자 추가 부여

### DIFF
--- a/src/main/java/zerobase/sijak/service/NicknameService.java
+++ b/src/main/java/zerobase/sijak/service/NicknameService.java
@@ -26,10 +26,15 @@ public class NicknameService {
     public String generate() {
         // 랜덤 형용사
         String adjective = ADJECTIVES[RANDOM.nextInt(ADJECTIVES.length)];
+
+        // 랜덤 숫자
+        int randomNumber = RANDOM.nextInt(10000);
+        String randomInt = String.format("%04d", randomNumber);
+
         // 랜덤 명사
         String noun = NOUNS[RANDOM.nextInt(NOUNS.length)];
 
-        return MessageFormat.format("{0}{1}", adjective, noun);
+        return MessageFormat.format("{0}{1}#{2}", adjective, noun, randomInt);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#60 

## 📝작업 내용

랜덤 닉네임에 4자리의 랜덤 숫자까지 함께 나타날 수 있도록 기능을 추가했습니다.

### 스크린샷

![image](https://github.com/user-attachments/assets/aa9a80cc-193e-46d7-b696-405fb90498b6)


## 💬리뷰 요구사항


