### PR TITLE
[Feat] 찜 개수 표시 기능 추가

### DIFF
--- a/src/main/java/zerobase/sijak/dto/LectureDetailResponse.java
+++ b/src/main/java/zerobase/sijak/dto/LectureDetailResponse.java
@@ -53,6 +53,9 @@ public class LectureDetailResponse {
     @JsonProperty("d_day")
     private long dDay;
 
+    @JsonProperty("heart_count")
+    private int heartCount;
+
     private String category;
 
     private String condition;

--- a/src/main/java/zerobase/sijak/persist/repository/HeartRepository.java
+++ b/src/main/java/zerobase/sijak/persist/repository/HeartRepository.java
@@ -37,6 +37,11 @@ public interface HeartRepository extends JpaRepository<Heart, Integer> {
             "AND (:mode = false OR l.status = true)")
     long countByLectureIdAndMemberIdAndMode(@Param("memberId") Integer memberId, @Param("mode") boolean mode);
 
+    @Query("SELECT COUNT(h) " +
+            "FROM Heart h " +
+            "WHERE h.lecture.id = :lectureId")
+    int countHeartByLectureId(@Param("lectureId") Integer lectureId);
+
     @Modifying
     @Transactional
     @Query("DELETE FROM Heart h " +

--- a/src/main/java/zerobase/sijak/service/LectureService.java
+++ b/src/main/java/zerobase/sijak/service/LectureService.java
@@ -16,6 +16,7 @@ import zerobase.sijak.persist.domain.Educate;
 import zerobase.sijak.persist.domain.Lecture;
 import zerobase.sijak.persist.domain.Member;
 import zerobase.sijak.persist.repository.EducateRepository;
+import zerobase.sijak.persist.repository.HeartRepository;
 import zerobase.sijak.persist.repository.LectureRepository;
 import zerobase.sijak.persist.repository.MemberRepository;
 
@@ -39,6 +40,7 @@ public class LectureService {
 
     private final double EARTH_RADIUS_KM = 6371.0;
     private final EducateRepository educateRepository;
+    private final HeartRepository heartRepository;
 
     public Slice<LectureHomeResponse> readHome(String token, Pageable pageable) {
 
@@ -230,6 +232,7 @@ public class LectureService {
                 plan.put(i, String.valueOf(educateList.get(i - 1).getContent()));
             }
 
+            int heart_count = heartRepository.countHeartByLectureId(lecture.getId());
             LectureDetailResponse lectureDetailResponse = LectureDetailResponse.builder()
                     .id(lecture.getId())
                     .name(lecture.getName())
@@ -249,6 +252,7 @@ public class LectureService {
                     .condition(lecture.getTarget())
                     .latitude(lecture.getLatitude())
                     .longitude(lecture.getLongitude())
+                    .heartCount(heart_count)
                     .category("미정")
                     .dDay(-dDay)
                     .plan(plan)
@@ -311,6 +315,7 @@ public class LectureService {
                 plan.put(i, String.valueOf(educateList.get(i - 1).getContent()));
             }
 
+            int heart_count = heartRepository.countHeartByLectureId(lecture.getId());
             LectureDetailResponse lectureDetailResponse = LectureDetailResponse.builder()
                     .id(lecture.getId())
                     .name(lecture.getName())
@@ -334,6 +339,7 @@ public class LectureService {
                     .dDay(-dDay)
                     .detail(lecture.getDescription())
                     .certification(lecture.getCertification())
+                    .heartCount(heart_count)
                     .category("미정")
                     .textBookName(lecture.getTextBookName())
                     .textBookPrice(lecture.getTextBookPrice())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#64 

## 📝 작업 내용

상세 페이지에서 해당 강좌를 몇 명의 회원이 찜 리스트에 넣어놓았는지 확인할 수 있도록 개수를 표시하는 기능을 추가하였습니다.
해당 기능은 ```JPQL```을 사용하여 구현하였습니다.

## 💬 리뷰 요구사항
